### PR TITLE
Collapsable sections in provider

### DIFF
--- a/CollectionView.xcodeproj/project.pbxproj
+++ b/CollectionView.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1C2DC5171E329CA000EBC234 /* IndexedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2DC5161E329CA000EBC234 /* IndexedSet.swift */; };
 		1C6E50851E2D9C2A00C85946 /* ResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6E50821E2D9C2A00C85946 /* ResultsController.swift */; };
+		1CB3A3D02075651900A2AB9B /* ReaultionalRCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB3A3CF2075651900A2AB9B /* ReaultionalRCTests.swift */; };
 		1CC05C221FF6F564001E6936 /* MutableResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC05C211FF6F564001E6936 /* MutableResultsController.swift */; };
 		DE13C18B1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */; };
 		DE297DE01E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE297DDF1E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift */; };
@@ -29,7 +30,7 @@
 		DE98600B1E6F956100B6A3EC /* FetchedSetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE98600A1E6F956100B6A3EC /* FetchedSetController.swift */; };
 		DE9A6220203782F100210035 /* MRCValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9A621F203782F100210035 /* MRCValueTests.swift */; };
 		DE9A6222203CBE7200210035 /* SectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9A6221203CBE7200210035 /* SectionInfo.swift */; };
-		DE9A6224203CE8CC00210035 /* FRCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE90669E2034E5F8007B73E7 /* FRCTests.swift */; };
+		DE9A6224203CE8CC00210035 /* FetchedRCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE90669E2034E5F8007B73E7 /* FetchedRCTests.swift */; };
 		DE9A6226203D1B9500210035 /* CoreDataResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6E50811E2D9C2A00C85946 /* CoreDataResultsController.swift */; };
 		DE9A6228203E6B8900210035 /* MRCObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9A6227203E6B8900210035 /* MRCObjectTests.swift */; };
 		DEA638B1200874950023F2BD /* SelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA638B0200874950023F2BD /* SelectionTests.swift */; };
@@ -67,6 +68,7 @@
 		1C2DC5161E329CA000EBC234 /* IndexedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexedSet.swift; sourceTree = "<group>"; };
 		1C6E50811E2D9C2A00C85946 /* CoreDataResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataResultsController.swift; sourceTree = "<group>"; };
 		1C6E50821E2D9C2A00C85946 /* ResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsController.swift; sourceTree = "<group>"; };
+		1CB3A3CF2075651900A2AB9B /* ReaultionalRCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaultionalRCTests.swift; sourceTree = "<group>"; };
 		1CC05C211FF6F564001E6936 /* MutableResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableResultsController.swift; sourceTree = "<group>"; };
 		DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectContextObservationCoordinator.swift; sourceTree = "<group>"; };
 		DE1EE9A42072B00B00B76FE2 /* CollapsableCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsableCollectionViewProvider.swift; sourceTree = "<group>"; };
@@ -84,7 +86,7 @@
 		DE82E95D1D78BFC900346B9E /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		DE8B448920337DC100F16614 /* OrderedSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSetTests.swift; sourceTree = "<group>"; };
 		DE8B448B2033903500F16614 /* IndexedSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedSetTests.swift; sourceTree = "<group>"; };
-		DE90669E2034E5F8007B73E7 /* FRCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRCTests.swift; sourceTree = "<group>"; };
+		DE90669E2034E5F8007B73E7 /* FetchedRCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedRCTests.swift; sourceTree = "<group>"; };
 		DE9071E91CAC7FD800AD0E37 /* CollectionView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CollectionView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE9071EC1CAC7FD800AD0E37 /* CollectionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CollectionView.h; sourceTree = "<group>"; };
 		DE9071EE1CAC7FD800AD0E37 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -239,7 +241,8 @@
 				DEB3AC24204DB90A00E18358 /* CVProxyTests.swift */,
 				DE8B448920337DC100F16614 /* OrderedSetTests.swift */,
 				DE8B448B2033903500F16614 /* IndexedSetTests.swift */,
-				DE90669E2034E5F8007B73E7 /* FRCTests.swift */,
+				DE90669E2034E5F8007B73E7 /* FetchedRCTests.swift */,
+				1CB3A3CF2075651900A2AB9B /* ReaultionalRCTests.swift */,
 				DE9A621F203782F100210035 /* MRCValueTests.swift */,
 				DE9A6227203E6B8900210035 /* MRCObjectTests.swift */,
 				DEA638B2200874950023F2BD /* Info.plist */,
@@ -408,7 +411,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DE9A6224203CE8CC00210035 /* FRCTests.swift in Sources */,
+				DE9A6224203CE8CC00210035 /* FetchedRCTests.swift in Sources */,
+				1CB3A3D02075651900A2AB9B /* ReaultionalRCTests.swift in Sources */,
 				DE9A6228203E6B8900210035 /* MRCObjectTests.swift in Sources */,
 				DE8B448A20337DC100F16614 /* OrderedSetTests.swift in Sources */,
 				DEB3AC25204DB90A00E18358 /* CVProxyTests.swift in Sources */,

--- a/CollectionView.xcodeproj/project.pbxproj
+++ b/CollectionView.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		DEA638B3200874950023F2BD /* CollectionView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE9071E91CAC7FD800AD0E37 /* CollectionView.framework */; };
 		DEA6BA631D52E00900B3EF24 /* CollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BA621D52E00900B3EF24 /* CollectionViewController.swift */; };
 		DEAFE2A71E41655C00FCF9C6 /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAFE2A61E41655C00FCF9C6 /* OrderedSet.swift */; };
-		DEB0F4401E4105D100C2260B /* DelegateChangeSets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB0F43F1E4105D100C2260B /* DelegateChangeSets.swift */; };
+		DEB0F4401E4105D100C2260B /* CollectionViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB0F43F1E4105D100C2260B /* CollectionViewProvider.swift */; };
 		DEB3AC25204DB90A00E18358 /* CVProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3AC24204DB90A00E18358 /* CVProxyTests.swift */; };
 		DEB4D5631E64EEC00044026F /* CollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECA70CB1D8751010006D795 /* CollectionViewFlowLayout.swift */; };
 		DEB7366A1E8599E7008467F8 /* CollectionViewPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB736671E8599E7008467F8 /* CollectionViewPreviewController.swift */; };
@@ -69,6 +69,7 @@
 		1C6E50821E2D9C2A00C85946 /* ResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsController.swift; sourceTree = "<group>"; };
 		1CC05C211FF6F564001E6936 /* MutableResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableResultsController.swift; sourceTree = "<group>"; };
 		DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectContextObservationCoordinator.swift; sourceTree = "<group>"; };
+		DE1EE9A42072B00B00B76FE2 /* CollapsableCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsableCollectionViewProvider.swift; sourceTree = "<group>"; };
 		DE297DDF1E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupplementaryViewIdentifier.swift; sourceTree = "<group>"; };
 		DE35BE1E20376FCC008FEF6F /* SortDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortDescriptor.swift; sourceTree = "<group>"; };
 		DE3E47551E4259B800F19D9E /* EditDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditDistance.swift; sourceTree = "<group>"; };
@@ -104,7 +105,7 @@
 		DEA638B2200874950023F2BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEA6BA621D52E00900B3EF24 /* CollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewController.swift; sourceTree = "<group>"; };
 		DEAFE2A61E41655C00FCF9C6 /* OrderedSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedSet.swift; sourceTree = "<group>"; };
-		DEB0F43F1E4105D100C2260B /* DelegateChangeSets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateChangeSets.swift; sourceTree = "<group>"; };
+		DEB0F43F1E4105D100C2260B /* CollectionViewProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewProvider.swift; sourceTree = "<group>"; };
 		DEB3AC24204DB90A00E18358 /* CVProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVProxyTests.swift; sourceTree = "<group>"; };
 		DEB736671E8599E7008467F8 /* CollectionViewPreviewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewPreviewController.swift; sourceTree = "<group>"; };
 		DEB736681E8599E7008467F8 /* CollectionViewPreviewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewPreviewLayout.swift; sourceTree = "<group>"; };
@@ -139,7 +140,8 @@
 			isa = PBXGroup;
 			children = (
 				1C6E50821E2D9C2A00C85946 /* ResultsController.swift */,
-				DEB0F43F1E4105D100C2260B /* DelegateChangeSets.swift */,
+				DEB0F43F1E4105D100C2260B /* CollectionViewProvider.swift */,
+				DE1EE9A42072B00B00B76FE2 /* CollapsableCollectionViewProvider.swift */,
 				DE9A6221203CBE7200210035 /* SectionInfo.swift */,
 				1CC05C211FF6F564001E6936 /* MutableResultsController.swift */,
 				1C6E50811E2D9C2A00C85946 /* CoreDataResultsController.swift */,
@@ -369,7 +371,7 @@
 				DE9A6226203D1B9500210035 /* CoreDataResultsController.swift in Sources */,
 				DE82E95C1D78BF9300346B9E /* Protocols.swift in Sources */,
 				DEB4D5631E64EEC00044026F /* CollectionViewFlowLayout.swift in Sources */,
-				DEB0F4401E4105D100C2260B /* DelegateChangeSets.swift in Sources */,
+				DEB0F4401E4105D100C2260B /* CollectionViewProvider.swift in Sources */,
 				DE98600B1E6F956100B6A3EC /* FetchedSetController.swift in Sources */,
 				DEE3B5851D246CB100AD34F1 /* CollectionViewListLayout.swift in Sources */,
 				DEB7366A1E8599E7008467F8 /* CollectionViewPreviewController.swift in Sources */,

--- a/CollectionView.xcodeproj/xcshareddata/xcschemes/CollectionViewTests.xcscheme
+++ b/CollectionView.xcodeproj/xcshareddata/xcschemes/CollectionViewTests.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/CollectionView/CollapsableCollectionViewProvider.swift
+++ b/CollectionView/CollapsableCollectionViewProvider.swift
@@ -1,0 +1,103 @@
+//
+//  CollapsableCollectionViewProvider.swift
+//  CollectionView
+//
+//  Created by Wesley Byrne on 4/2/18.
+//  Copyright © 2018 Noun Project. All rights reserved.
+//
+
+import Foundation
+
+
+public class CollapsableCollectionViewProvider : CollectionViewResultsProxy {
+    
+    /// When set as the delegate
+    public unowned let collectionView : CollectionView
+    public unowned let resultsController : ResultsController
+    public weak var delegate: CollectionViewProviderDelegate?
+    
+    /// The last known section count of real data
+    private var sectionCount = 0
+    
+    public init(_ collectionView: CollectionView, resultsController: ResultsController) {
+        self.collectionView = collectionView
+        self.resultsController = resultsController
+        self.sectionCount = resultsController.numberOfSections
+        super.init()
+        self.resultsController.delegate = self
+    }
+    
+    /**
+     If true, a cell will be inserted when a section becomes empty
+     
+     ## Discussion
+     When displaying sections within a CollectionView, it can be helpful to fill empty sections with a placholder cell. This causes an issue when responding to updates from a results controller. For example, when an object is inserted into an empty section, the results controller will report a single insert change. The CollectionView though would need to remove the exisitng cell AND insert the new one.
+     
+     Setting hasEmptySectionPlaceholders to true, will report changes as such, making it easy to propagate the reported changes to a CollectionView.
+     
+     */
+    public var populateEmptySections = false
+    
+    /**
+     If true, a cell will be inserted when a collection view becomes completely empty
+     
+     ## Discussion
+     When displaying sections within a CollectionView, it can be helpful to display a cell representing the empty state. This causes an issue when responding to updates from a results controller. For example, when the last section is removed from a data source (i.e. ResultsController), the controller will report a single remove change. The CollectionView though would need to remove those cells AND insert the new one to act as the palceholder.
+     
+     Setting populateWhenEmpty to true, will report changes as such, making it easy to propagate the reported changes to a CollectionView.
+     
+     */
+    public var populateWhenEmpty = false
+    
+    
+    
+}
+
+// MARK: - Results Controller Delegate
+/*-------------------------------------------------------------------------------*/
+extension CollapsableCollectionViewProvider : ResultsControllerDelegate {
+    
+    public func controllerDidLoadContent(controller: ResultsController) {
+        self.sectionCount = controller.numberOfSections
+    }
+    
+    public func controllerWillChangeContent(controller: ResultsController) {
+        self.prepareForUpdates()
+        self.delegate?.providerWillChangeContent(self)
+    }
+    
+    public func controller(_ controller: ResultsController, didChangeObject object: Any, at indexPath: IndexPath?, for changeType: ResultsControllerChangeType) {
+        self.delegate?.provider(self, didUpdateItem: object, at: indexPath, for: changeType)
+        self.addChange(forItemAt: indexPath, with: changeType)
+    }
+    
+    public func controller(_ controller: ResultsController, didChangeSection section: Any, at indexPath: IndexPath?, for changeType: ResultsControllerChangeType) {
+        self.delegate?.provider(self, didUpdateSection: section, at: indexPath, for: changeType)
+        self.addChange(forSectionAt: indexPath, with: changeType)
+    }
+    
+    public func controllerDidChangeContent(controller: ResultsController) {
+        defer {
+            self.sectionCount = controller.numberOfSections
+        }
+        if self.populateWhenEmpty {
+            let isEmpty = controller.numberOfSections == 0
+            let wasEmpty = self.sectionCount == 0
+            if !wasEmpty && isEmpty {
+                // populate
+                self.addChange(forSectionAt: nil, with: .insert(IndexPath.zero))
+            }
+            else if wasEmpty && !isEmpty {
+                // Remove placeholder
+                self.addChange(forSectionAt: IndexPath.zero, with: .delete)
+            }
+        }
+        else if self.populateEmptySections && controller.numberOfSections > 0 {
+            
+        }
+        let completion = self.delegate?.providerDidChangeContent(self)
+        self.collectionView.applyChanges(from: self, completion: completion)
+    }
+}
+
+

--- a/CollectionView/CollectionView.swift
+++ b/CollectionView/CollectionView.swift
@@ -1054,7 +1054,7 @@ open class CollectionView : ScrollView, NSDraggingSource {
         guard indexPaths.count > 0 else { return }
         self.beginEditing()
         self._updateContext.items.inserted.formUnion(indexPaths)
-//        self._insertItems(at: indexPaths)
+
         self.endEditing(animated)
     }
     

--- a/CollectionView/CollectionViewProvider.swift
+++ b/CollectionView/CollectionViewProvider.swift
@@ -18,8 +18,8 @@ public struct ResultsChangeSet { }
 
 /// A Helper to 
 public class CollectionViewResultsProxy   {
-    var items = ItemChangeSet()
-    var sections = SectionChangeSet()
+    var itemUpdates = ItemChangeSet()
+    var sectionUpdates = SectionChangeSet()
     
     
     /**
@@ -30,7 +30,7 @@ public class CollectionViewResultsProxy   {
      
      */
     public func addChange(forItemAt source: IndexPath?, with changeType: ResultsControllerChangeType) {
-        items.addChange(forItemAt: source, with: changeType)
+        itemUpdates.addChange(forItemAt: source, with: changeType)
     }
     
     
@@ -43,15 +43,15 @@ public class CollectionViewResultsProxy   {
      
      */
     public func addChange(forSectionAt source: IndexPath?, with changeType: ResultsControllerChangeType) {
-        sections.addChange(forSectionAt: source, with: changeType)
+        sectionUpdates.addChange(forSectionAt: source, with: changeType)
     }
     
     public func didInsertSection(at indexPath: IndexPath) -> Bool {
-        return self.sections.inserted.contains(indexPath._section)
+        return self.sectionUpdates.inserted.contains(indexPath._section)
     }
     
     public func didInsertObject(at indexPath: IndexPath) -> Bool {
-        return self.items.inserted.contains(indexPath)
+        return self.itemUpdates.inserted.contains(indexPath)
     }
     
     /// The count of changes in the set
@@ -59,16 +59,16 @@ public class CollectionViewResultsProxy   {
         return itemChangeCount + sectionChangeCount
     }
     public var itemChangeCount : Int {
-        return items.count
+        return itemUpdates.count
     }
     public var sectionChangeCount : Int {
-        return sections.count
+        return sectionUpdates.count
     }
     
     
     public func prepareForUpdates() {
-        items.reset()
-        sections.reset()
+        itemUpdates.reset()
+        sectionUpdates.reset()
     }
     
     /**
@@ -78,13 +78,13 @@ public class CollectionViewResultsProxy   {
      
      */
     public func union(with other: CollectionViewResultsProxy) {
-        self.items.inserted.formUnion(other.items.inserted)
-        self.items.deleted.formUnion(other.items.deleted)
-        self.items.updated.formUnion(other.items.updated)
+        self.itemUpdates.inserted.formUnion(other.itemUpdates.inserted)
+        self.itemUpdates.deleted.formUnion(other.itemUpdates.deleted)
+        self.itemUpdates.updated.formUnion(other.itemUpdates.updated)
         
-        self.sections.inserted.formUnion(other.sections.inserted)
-        self.sections.deleted.formUnion(other.sections.deleted)
-        self.sections.updated.formUnion(other.sections.updated)
+        self.sectionUpdates.inserted.formUnion(other.sectionUpdates.inserted)
+        self.sectionUpdates.deleted.formUnion(other.sectionUpdates.deleted)
+        self.sectionUpdates.updated.formUnion(other.sectionUpdates.updated)
     }
 }
 
@@ -149,17 +149,57 @@ public class CollectionViewProvider : CollectionViewResultsProxy {
     public var populateWhenEmpty = false
     
     
+    private class Section : Equatable, CustomStringConvertible {
+        var source : Int?
+        var target: Int?
+        var dataCount : Int = 0
+        var displayCount : Int = 0
+        
+        init(source: Int?, target: Int?, dataCount: Int, displayCount: Int) {
+            self.source = source
+            self.target = target
+            self.dataCount = dataCount
+            self.displayCount = displayCount
+        }
+        
+        static func ==(lhs: CollectionViewProvider.Section,
+                       rhs: CollectionViewProvider.Section) -> Bool {
+            return lhs.source == rhs.source && lhs.target == rhs.target
+        }
+        var description: String {
+            return "Source: \(source ?? -1) Target: \(self.target ?? -1) Count: \(self.dataCount)"
+        }
+    
+    }
+    
+    private var sections = [Section]()
+    
+    public override func prepareForUpdates() {
+        super.prepareForUpdates()
+        sections = (0..<resultsController.numberOfSections).map{
+            return Section(source: $0,
+                           target: nil,
+                           dataCount: resultsController.numberOfObjects(in: $0),
+                           displayCount: self.numberOfItems(in: $0))
+        }
+    }
+    
     var collapsedSections = Set<Int>()
     
-    func collapseSection(_ section: Int, animated: Bool) {
-        guard !collapsedSections.contains(section) else { return }
-        let ips = (0..<self.numberOfItems(in: section)).map { return IndexPath.for(item: $0, section: section) }
+    func isSectionCollapsed(at index: Int) -> Bool {
+        return collapsedSections.contains(index)
+    }
+    
+    func collapseSection(at sectionIndex: Int, animated: Bool) {
+        guard !collapsedSections.contains(sectionIndex) else { return }
+        let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
+        collapsedSections.insert(sectionIndex)
         self.collectionView.deleteItems(at: ips, animated: animated)
     }
     
-    func expandSection(_ section: Int, animated: Bool) {
-        guard collapsedSections.contains(section) else { return }
-        let ips = (0..<self.numberOfItems(in: section)).map { return IndexPath.for(item: $0, section: section) }
+    func expandSection(at sectionIndex: Int, animated: Bool) {
+        guard collapsedSections.remove(sectionIndex) != nil else { return }
+        let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
         self.collectionView.insertItems(at: ips, animated: animated)
     }
 }
@@ -230,9 +270,55 @@ extension CollectionViewProvider : ResultsControllerDelegate {
         defer {
             self.sectionCount = controller.numberOfSections
         }
-        if self.populateWhenEmpty {
-            let isEmpty = controller.numberOfSections == 0
-            let wasEmpty = self.sectionCount == 0
+        
+        let target = processSections()
+        
+        // If any of the sections are collapsed we may need to adjust some of the edits
+        if !collapsedSections.isEmpty {
+            var _collapsed = Set<Int>()
+            for sec in target {
+                if let s = sec?.source, let t = sec?.target, self.collapsedSections.contains(s) {
+                    _collapsed.insert(t)
+                }
+            }
+            
+            // Ignore deletes for collapsed sections
+            self.itemUpdates.deleted = self.itemUpdates.deleted.filter {
+                return !self.collapsedSections.contains($0._section)
+            }
+            // Ignore inserts for collapsed sections
+            self.itemUpdates.inserted = self.itemUpdates.inserted.filter {
+                return !self.collapsedSections.contains($0._section)
+            }
+            
+            // Ignore inserts for collapsed sections
+            var _moves = [ItemChangeSet.Move]()
+            for m in self.itemUpdates.moved {
+                let sourceCollapsed = collapsedSections.contains(m.source._section)
+                let targetCollapsed = _collapsed.contains(m.destination._section)
+                
+                if sourceCollapsed && !targetCollapsed {
+                    self.itemUpdates.inserted.insert(m.destination)
+                }
+                else if !sourceCollapsed && targetCollapsed {
+                    self.itemUpdates.deleted.insert(m.source)
+                }
+                else if !sourceCollapsed && !targetCollapsed {
+                    _moves.append(m)
+                }
+                // If both are collapsed, drop the update
+            }
+            self.itemUpdates.moved = _moves
+            
+            // Set the new collapsed sections
+            self.collapsedSections = _collapsed
+        }
+        
+        let isEmpty = controller.numberOfSections == 0
+        let wasEmpty = self.sectionCount == 0
+        
+        if self.populateWhenEmpty && isEmpty != wasEmpty {
+            
             if !wasEmpty && isEmpty {
                 // populate
                 self.addChange(forSectionAt: nil, with: .insert(IndexPath.zero))
@@ -243,10 +329,61 @@ extension CollectionViewProvider : ResultsControllerDelegate {
             }
         }
         else if self.populateEmptySections && controller.numberOfSections > 0 {
-            
+            for sec in target {
+                if let s = sec, s.source != nil, let t = s.target, !collapsedSections.contains(t) {
+                    let _isEmpty = controller.numberOfObjects(in: t) == 0
+                    let _wasEmpty = s.dataCount == 0
+                    if !_wasEmpty && _isEmpty {
+                        // populate
+                        self.addChange(forItemAt: nil, with: .insert(IndexPath.for(section: t)))
+                    }
+                    else if _wasEmpty && !_isEmpty {
+                        // Remove placeholder
+                        self.addChange(forItemAt: IndexPath.for(section: t), with: .delete)
+                    }
+                }
+            }
         }
         let completion = self.delegate?.providerDidChangeContent(self)
         self.collectionView.applyChanges(from: self, completion: completion)
+    }
+    
+    private func processSections() -> [Section?] {
+        var source = self.sections
+        var target = [Section?](repeatElement(nil, count: resultsController.numberOfSections))
+        
+        // Populate target with inserted
+        for s in sectionUpdates.inserted {
+            target[s] = Section(source: nil,
+                                target: s,
+                                dataCount: resultsController.numberOfObjects(in: s),
+                                displayCount: 0)
+        }
+        
+        // The things in source that we want to ignore beow
+        var transferred = sectionUpdates.deleted
+        
+        // Populate target with moved
+        for m in sectionUpdates.moved {
+            transferred.insert(m.0)
+            source[m.0].target = m.1
+            target[m.1] = source[m.0]
+        }
+        
+        // Insert the remaining sections from source that are carrying over (not deleted)
+        // After this target should be fully populated
+        var idx = 0
+        func incrementInsert() {
+            while idx < target.count && target[idx] != nil {
+                idx += 1
+            }
+        }
+        for section in source where !transferred.contains(section.source!) {
+            incrementInsert()
+            section.target = idx
+            target[idx] = section
+        }
+        return target
     }
 }
 
@@ -353,8 +490,8 @@ public extension CollectionView {
         }
 
         self.performBatchUpdates({
-            _applyChanges(changeSet.items)
-            _applyChanges(changeSet.sections)
+            _applyChanges(changeSet.itemUpdates)
+            _applyChanges(changeSet.sectionUpdates)
         }, completion: completion)
     }
     

--- a/CollectionView/CollectionViewProvider.swift
+++ b/CollectionView/CollectionViewProvider.swift
@@ -148,8 +148,20 @@ public class CollectionViewProvider : CollectionViewResultsProxy {
      */
     public var populateWhenEmpty = false
     
-
-
+    
+    var collapsedSections = Set<Int>()
+    
+    func collapseSection(_ section: Int, animated: Bool) {
+        guard !collapsedSections.contains(section) else { return }
+        let ips = (0..<self.numberOfItems(in: section)).map { return IndexPath.for(item: $0, section: section) }
+        self.collectionView.deleteItems(at: ips, animated: animated)
+    }
+    
+    func expandSection(_ section: Int, animated: Bool) {
+        guard collapsedSections.contains(section) else { return }
+        let ips = (0..<self.numberOfItems(in: section)).map { return IndexPath.for(item: $0, section: section) }
+        self.collectionView.insertItems(at: ips, animated: animated)
+    }
 }
 
 
@@ -168,6 +180,9 @@ extension CollectionViewProvider {
     public func numberOfItems(in section: Int) -> Int {
         guard resultsController.numberOfSections > 0 else {
             return 1 // Must be populated empty state
+        }
+        if self.collapsedSections.contains(section) {
+            return 0
         }
         let count = resultsController.numberOfObjects(in: section)
         if count == 0 && self.populateEmptySections {
@@ -233,7 +248,6 @@ extension CollectionViewProvider : ResultsControllerDelegate {
         let completion = self.delegate?.providerDidChangeContent(self)
         self.collectionView.applyChanges(from: self, completion: completion)
     }
-    
 }
 
 
@@ -244,6 +258,9 @@ extension CollectionViewResultsProxy {
         self.prepareForUpdates()
     }
 }
+
+
+
 
 
 struct ItemChangeSet {

--- a/CollectionView/CollectionViewProvider.swift
+++ b/CollectionView/CollectionViewProvider.swift
@@ -208,14 +208,14 @@ public class CollectionViewProvider : CollectionViewResultsProxy {
     }
     
     public func collapseSection(at sectionIndex: Int, animated: Bool) {
-        guard !collapsedSections.contains(sectionIndex) else { return }
+        guard !collapsedSections.contains(sectionIndex), self.numberOfItems(in: sectionIndex) > 0 else { return }
         let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
         collapsedSections.insert(sectionIndex)
         self.collectionView.deleteItems(at: ips, animated: animated)
     }
     
     public func expandSection(at sectionIndex: Int, animated: Bool) {
-        guard collapsedSections.remove(sectionIndex) != nil else { return }
+        guard collapsedSections.remove(sectionIndex) != nil, self.numberOfItems(in: sectionIndex) > 0 else { return }
         let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
         self.collectionView.insertItems(at: ips, animated: animated)
     }

--- a/CollectionView/CollectionViewProvider.swift
+++ b/CollectionView/CollectionViewProvider.swift
@@ -208,14 +208,14 @@ public class CollectionViewProvider : CollectionViewResultsProxy {
     }
     
     public func collapseSection(at sectionIndex: Int, animated: Bool) {
-        guard !collapsedSections.contains(sectionIndex), self.numberOfItems(in: sectionIndex) > 0 else { return }
+        guard !collapsedSections.contains(sectionIndex) else { return }
         let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
         collapsedSections.insert(sectionIndex)
         self.collectionView.deleteItems(at: ips, animated: animated)
     }
     
     public func expandSection(at sectionIndex: Int, animated: Bool) {
-        guard collapsedSections.remove(sectionIndex) != nil, self.numberOfItems(in: sectionIndex) > 0 else { return }
+        guard collapsedSections.remove(sectionIndex) != nil else { return }
         let ips = (0..<self.numberOfItems(in: sectionIndex)).map { return IndexPath.for(item: $0, section: sectionIndex) }
         self.collectionView.insertItems(at: ips, animated: animated)
     }
@@ -294,7 +294,7 @@ extension CollectionViewProvider : ResultsControllerDelegate {
         let target = processSections()
         
         // If any of the sections are collapsed we may need to adjust some of the edits
-        if !collapsedSections.isEmpty || defaultCollapse {
+        if !self.collapsedSections.isEmpty || self.defaultCollapse {
             var _collapsed = Set<Int>()
             for sec in target {
                 if let s = sec?.source, self.collapsedSections.contains(s),
@@ -312,7 +312,7 @@ extension CollectionViewProvider : ResultsControllerDelegate {
             }
             // Ignore inserts for collapsed sections
             self.itemUpdates.inserted = self.itemUpdates.inserted.filter {
-                return !self.collapsedSections.contains($0._section)
+                return !_collapsed.contains($0._section)
             }
             
             // Ignore inserts for collapsed sections

--- a/CollectionView/CoreDataResultsController.swift
+++ b/CollectionView/CoreDataResultsController.swift
@@ -344,7 +344,7 @@ public class RelationalResultsController<Section: NSManagedObject, Element: NSMa
      
      For custom names, leave nil and conform your section objects to CustomDisplayStringConvertible
      */
-    public var sectionNameKeyPath : String?
+    public var sectionNameKeyPath : KeyPath<Section, String>?
     
     
     /**
@@ -367,9 +367,9 @@ public class RelationalResultsController<Section: NSManagedObject, Element: NSMa
         guard let obj = sectionInfo(at: indexPath)?.representedObject else {
             return "Ungrouped"
         }
-        if let key = self.sectionNameKeyPath,
-            let val = obj.value(forKeyPath: key) as? CustomDisplayStringConvertible {
-            return val.displayDescription
+        if let key = self.sectionNameKeyPath {
+            let val = obj[keyPath: key]
+            return val
         }
         return (obj as? CustomDisplayStringConvertible)?.displayDescription ?? ""
     }

--- a/CollectionView/DataStructures/IndexedSet.swift
+++ b/CollectionView/DataStructures/IndexedSet.swift
@@ -39,6 +39,9 @@ public struct IndexedSet<Index: Hashable, Value: Hashable> : Sequence, CustomDeb
     public var count : Int {
         return byValue.count
     }
+    public var isEmpty : Bool {
+        return byValue.isEmpty
+    }
     
     public func value(for index: Index) -> Value? {
         return byIndex[index]

--- a/CollectionViewTests/CVProxyTests.swift
+++ b/CollectionViewTests/CVProxyTests.swift
@@ -35,6 +35,7 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         provider.populateWhenEmpty = false
         provider.populateEmptySections = false
+        provider.defaultCollapse = false
         resultsController.reset()
         collectionView.reloadData()
     }
@@ -240,6 +241,48 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
         
         provider.expandSection(at: 1, animated: false)
         self.assertCounts([4, 6])
+    }
+    
+    func testDefaultCollapsed() {
+        
+        var children = [Child]()
+        children.append(contentsOf: Parent(rank: 0).createChildren(5))
+        children.append(contentsOf: Parent(rank: 1).createChildren(5))
+        
+        provider.defaultCollapse = true
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        
+        self.assertCounts([0, 0])
+        XCTAssertTrue(provider.isSectionCollapsed(at: 0))
+        XCTAssertTrue(provider.isSectionCollapsed(at: 1))
+        
+        let c = Parent(rank: 2).createChildren(1)
+        resultsController.insert(object: c[0])
+        self.assertCounts([0, 0, 0])
+        XCTAssertTrue(provider.isSectionCollapsed(at: 2))
+    }
+    
+    func testDefaultCollapsedOnInsert() {
+        
+        var children = [Child]()
+        children.append(contentsOf: Parent(rank: 0).createChildren(5))
+        children.append(contentsOf: Parent(rank: 1).createChildren(5))
+        
+        provider.defaultCollapse = true
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        
+        provider.expandSection(at: 0, animated: false)
+        
+        self.assertCounts([5, 0])
+        XCTAssertFalse(provider.isSectionCollapsed(at: 0))
+        XCTAssertTrue(provider.isSectionCollapsed(at: 1))
+        
+        let c = Parent(rank: 2).createChildren(1)
+        resultsController.insert(object: c[0])
+        self.assertCounts([5, 0, 0])
+        XCTAssertTrue(provider.isSectionCollapsed(at: 2))
     }
     
     

--- a/CollectionViewTests/CVProxyTests.swift
+++ b/CollectionViewTests/CVProxyTests.swift
@@ -33,6 +33,8 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
+        provider.populateWhenEmpty = false
+        provider.populateEmptySections = false
         resultsController.reset()
         collectionView.reloadData()
     }
@@ -41,7 +43,6 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
     
     func numberOfSections(in collectionView: CollectionView) -> Int {
         return provider.numberOfSections
@@ -54,11 +55,197 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
     func collectionView(_ collectionView: CollectionView, cellForItemAt indexPath: IndexPath) -> CollectionViewCell {
         return CollectionViewCell.deque(for: indexPath, in: collectionView)
     }
-
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    func assertCounts(_ counts: [Int]) {
+        XCTAssertEqual(provider.numberOfSections, counts.count)
+        XCTAssertEqual(collectionView.numberOfSections, counts.count)
+        for (s, count) in counts.enumerated() {
+            XCTAssertEqual(provider.numberOfItems(in: s), count)
+            XCTAssertEqual(collectionView.numberOfItems(in: s), count)
+        }
+    }
+    
+    // MARK: - Placeholders
+    /*-------------------------------------------------------------------------------*/
+    
+    func testEmptyPlaceholder() {
+        provider.populateWhenEmpty = true
+        collectionView.reloadData()
         
+        self.assertCounts([1])
+        XCTAssertTrue(provider.showEmptyState)
+    }
+    
+    func testEmptyPlaceholderReplaced() {
+        // Start with empty placeholder and insert a section
+        provider.populateWhenEmpty = true
+        collectionView.reloadData()
+        
+        self.assertCounts([1])
+        resultsController.insert(section: Parent(rank: 0))
+        self.assertCounts([0])
+        XCTAssertFalse(provider.showEmptyState)
+    }
+    
+    func testEmptySectionPlaceholder() {
+        // Empty sections
+        provider.populateEmptySections = true
+        let p = Parent(rank: 0)
+        resultsController.setContent([(p, [])])
+        collectionView.reloadData()
+        
+        self.assertCounts([1])
+        XCTAssertFalse(provider.showEmptyState)
+        XCTAssertTrue(provider.showEmptySection(at: IndexPath.zero))
+    }
+    
+    
+    func testReplaceEmptySectionPlaceholder() {
+        // Empty sections
+        provider.populateEmptySections = true
+        let p = Parent(rank: 0)
+        resultsController.setContent([(p, [])])
+        collectionView.reloadData()
+        
+        resultsController.beginEditing()
+        for c in p.createChildren(5) {
+            resultsController.insert(object: c)
+        }
+        resultsController.endEditing()
+        XCTAssertFalse(provider.showEmptySection(at: IndexPath.zero))
+        self.assertCounts([5])
+        
+    }
+    
+    
+    
+    
+    // MARK: - Section Expanding
+    /*-------------------------------------------------------------------------------*/
+    
+    func testCollapseSection() {
+        
+        var children = [Child]()
+        for n in 0..<3 {
+            children.append(contentsOf: Parent(rank: n).createChildren(5))
+        }
+        
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        
+        self.assertCounts([5, 5, 5])
+        provider.collapseSection(at: 1, animated: false)
+        self.assertCounts([5, 0, 5])
+    }
+    
+    func testExpandSection() {
+        var children = [Child]()
+        for n in 0..<3 {
+            children.append(contentsOf: Parent(rank: n).createChildren(5))
+        }
+        
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+
+        provider.collapseSection(at: 1, animated: false)
+        self.assertCounts([5, 0, 5])
+        
+        provider.expandSection(at: 1, animated: false)
+        self.assertCounts([5, 5, 5])
+    }
+    
+    func testMoveCollapseSection() {
+        var children = [Child]()
+        var parents = [Parent]()
+        for n in 0..<3 {
+            let p = Parent(rank: n)
+            parents.append(p)
+            children.append(contentsOf: p.createChildren(5))
+        }
+        
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        provider.collapseSection(at: 1, animated: false)
+        
+        self.assertCounts([5, 0 ,5])
+        
+        // Edit the data
+        parents[0].rank = 1
+        parents[1].rank = 0
+        self.resultsController.beginEditing()
+        self.resultsController.didUpdate(section: parents[0])
+        self.resultsController.didUpdate(section: parents[1])
+        self.resultsController.endEditing()
+        
+        XCTAssertTrue(provider.isSectionCollapsed(at: 0))
+        XCTAssertFalse(provider.isSectionCollapsed(at: 1))
+        self.assertCounts([0, 5 ,5])
+        
+        provider.expandSection(at: 0, animated: false)
+        XCTAssertFalse(provider.isSectionCollapsed(at: 1))
+        self.assertCounts([5, 5 ,5])
+    }
+    
+    func testMoveItemsFromCollapsedToExpanded() {
+        
+        let p0 = Parent(rank: 0)
+        let p1 = Parent(rank: 1)
+        let c0 = p0.createChildren(5)
+        let c1 = p1.createChildren(5)
+        
+        let children = [c0, c1].flatMap { return $0 }
+        
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        provider.collapseSection(at: 0, animated: false)
+        
+        self.assertCounts([0, 5])
+        
+        // Edit the data
+        c0[0].parent = p1
+        
+        self.resultsController.beginEditing()
+        self.resultsController.didUpdate(object: c0[0])
+        self.resultsController.endEditing()
+        
+        self.assertCounts([0, 6])
+        
+        provider.expandSection(at: 0, animated: false)
+        self.assertCounts([4, 6])
+    }
+    
+    func testMoveItemsFromExpandedToCollapsed() {
+        
+        let p0 = Parent(rank: 0)
+        let p1 = Parent(rank: 1)
+        let c0 = p0.createChildren(5)
+        let c1 = p1.createChildren(5)
+        
+        let children = [c0, c1].flatMap { return $0 }
+        
+        resultsController.setContent(objects: children)
+        collectionView.reloadData()
+        provider.collapseSection(at: 1, animated: false)
+        
+        self.assertCounts([5, 0])
+        
+        // Edit the data
+        c0[0].parent = p1
+        
+        self.resultsController.beginEditing()
+        self.resultsController.didUpdate(object: c0[0])
+        self.resultsController.endEditing()
+        
+        self.assertCounts([4, 0])
+        
+        provider.expandSection(at: 1, animated: false)
+        self.assertCounts([4, 6])
+    }
+    
+    
+
+    func testBreakingUseCase1() {
+        // A reproduction of a previously breaking case from the demo app
         let _data : [(String,[String])] = [
             ("ZSnKWisBqE", ["ueHNbNmzJE","BLDDODjZeP","eObJUPufpv","dOwXZZpyif","RIZOqeMoWM","hGLYuDzKQi","ZOAwicSMDE"]),
             ("WqoQBTNEaY", ["rsubjBxbVb","zgxqrwEMEP","RFMVhYUOBt","TPtWHpAfhO","vGNjxxuxds","EEQzPOqFLm","WqWAgYBpdk"]),
@@ -139,14 +326,8 @@ class CVProxyTests: XCTestCase, CollectionViewDataSource {
        
         
     }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+    
+    
 }
 
 

--- a/CollectionViewTests/FRCTests.swift
+++ b/CollectionViewTests/FRCTests.swift
@@ -98,8 +98,8 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         self._expectation = expectation(description: "Delegate")
         _ = Child.createOrphan(in: context)
         waitForExpectations(timeout: 0.1) { (err) in
-            XCTAssertEqual(self.changeSet.items.inserted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.inserted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.inserted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.inserted.count, 1)
             XCTAssertEqual(frc.numberOfSections, 1)
             XCTAssertEqual(frc.numberOfObjects(in: 0), 1)
         }
@@ -115,8 +115,8 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         _ = self.createItemsBySection(1, items: 5)
         
         waitForExpectations(timeout: 0.1) { (err) in
-            XCTAssertEqual(self.changeSet.items.inserted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.inserted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.inserted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.inserted.count, 1)
             XCTAssertEqual(frc.numberOfSections, 1)
             XCTAssertEqual(frc.numberOfObjects(in: 0), 5)
         }
@@ -133,8 +133,8 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         self._expectation = expectation(description: "Delegate")
         _ = self.createItemsBySection(5, items: 5)
         waitForExpectations(timeout: 0.1) { (err) in
-            XCTAssertEqual(self.changeSet.items.inserted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.inserted.count, 5)
+            XCTAssertEqual(self.changeSet.itemUpdates.inserted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.inserted.count, 5)
             XCTAssertEqual(frc.numberOfSections, 5)
             for s in 0..<frc.numberOfSections {
                 XCTAssertEqual(frc.numberOfObjects(in: s), 5)
@@ -169,23 +169,23 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
     
     func test_delegate_removeItem_first() {
         _testRemoveItems(sections: 1, items: 10, indexPaths: [IndexPath.for(item: 0, section: 0)]) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 1)
-            XCTAssertEqual(self.changeSet.items.deleted.first, IndexPath.for(item: 0, section: 0))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.first, IndexPath.for(item: 0, section: 0))
             XCTAssertEqual(frc.numberOfObjects(in: 0), 9)
         }
     }
     func test_delegate_removeItem_middle() {
         _testRemoveItems(sections: 1, items: 10, indexPaths: [IndexPath.for(item: 5, section: 0)]) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 1)
-            XCTAssertEqual(self.changeSet.items.deleted.first, IndexPath.for(item: 5, section: 0))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.first, IndexPath.for(item: 5, section: 0))
             XCTAssertEqual(frc.numberOfObjects(in: 0), 9)
         }
     }
     
     func test_delegate_removeItem_last() {
         _testRemoveItems(sections: 1, items: 10, indexPaths: [IndexPath.for(item: 9, section: 0)]) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 1)
-            XCTAssertEqual(self.changeSet.items.deleted.first, IndexPath.for(item: 9, section: 0))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.first, IndexPath.for(item: 9, section: 0))
             XCTAssertEqual(frc.numberOfObjects(in: 0), 9)
         }
     }
@@ -198,9 +198,9 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         ]
         
         _testRemoveItems(sections: 4, items: 10, indexPaths: ips) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 3)
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 3)
             for ip in ips {
-                XCTAssertTrue(self.changeSet.items.deleted.contains(ip))
+                XCTAssertTrue(self.changeSet.itemUpdates.deleted.contains(ip))
             }
             XCTAssertEqual(frc.numberOfObjects(in: 0), 9)
             XCTAssertEqual(frc.numberOfObjects(in: 1), 9)
@@ -212,9 +212,9 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
     func test_delegate_removeAllItemsfromSection() {
         let ips = IndexPath.inRange(0..<5, section: 0)
         _testRemoveItems(sections: 4, items: 5, indexPaths: ips) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.deleted.count, 1)
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(0))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.deleted.count, 1)
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(0))
             XCTAssertEqual(frc.numberOfSections, 3)
             XCTAssertEqual(frc.numberOfObjects(in: 0), 5)
             XCTAssertEqual(frc.numberOfObjects(in: 1), 5)
@@ -225,9 +225,9 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
     func test_delegate_removeAllItemsfromLastSection() {
         let ips = IndexPath.inRange(0..<5, section: 3)
         _testRemoveItems(sections: 4, items: 5, indexPaths: ips) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.deleted.count, 1)
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(3))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.deleted.count, 1)
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(3))
             XCTAssertEqual(frc.numberOfSections, 3)
             XCTAssertEqual(frc.numberOfObjects(in: 0), 5)
             XCTAssertEqual(frc.numberOfObjects(in: 1), 5)
@@ -241,12 +241,12 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         ips.append(contentsOf: IndexPath.inRange(0..<5, section: 3))
         
         _testRemoveItems(sections: 4, items: 5, indexPaths: ips) { (frc) in
-            XCTAssertEqual(self.changeSet.items.deleted.count, 0)
-            XCTAssertEqual(self.changeSet.sections.deleted.count, 4)
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(0))
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(1))
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(2))
-            XCTAssertTrue(self.changeSet.sections.deleted.contains(3))
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 0)
+            XCTAssertEqual(self.changeSet.sectionUpdates.deleted.count, 4)
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(0))
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(1))
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(2))
+            XCTAssertTrue(self.changeSet.sectionUpdates.deleted.contains(3))
             XCTAssertEqual(frc.numberOfSections, 0)
         }
     }
@@ -273,11 +273,11 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         
         self.waitForExpectations(timeout: 0.5) { (err) in
             // There should really only be one move
-            XCTAssertEqual(self.changeSet.items.count, 3)
-            XCTAssertEqual(self.changeSet.items.moved.count, 3)
+            XCTAssertEqual(self.changeSet.itemUpdates.count, 3)
+            XCTAssertEqual(self.changeSet.itemUpdates.moved.count, 3)
             print(self.changeSet)
             XCTAssertEqual(frc.object(at: IndexPath.zero), moved)
-            for move in self.changeSet.items.moved {
+            for move in self.changeSet.itemUpdates.moved {
                 XCTAssertEqual(children[move.source._section][move.source._item], frc.object(at: move.destination))
             }
         }
@@ -305,8 +305,8 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         
         self.waitForExpectations(timeout: 0.5) { (err) in
             // There should really only be one move
-            XCTAssertEqual(self.changeSet.items.count, 2)
-            XCTAssertEqual(self.changeSet.items.moved.count, 2)
+            XCTAssertEqual(self.changeSet.itemUpdates.count, 2)
+            XCTAssertEqual(self.changeSet.itemUpdates.moved.count, 2)
             print(self.changeSet)
             XCTAssertEqual(frc.numberOfObjects(in: 1), 7)
             XCTAssertEqual(frc.numberOfObjects(in: 2), 3)

--- a/CollectionViewTests/FetchedRCTests.swift
+++ b/CollectionViewTests/FetchedRCTests.swift
@@ -1,5 +1,5 @@
 //
-//  FRCTests.swift
+//  FetchedRCTests.swift
 //  CollectionViewTests
 //
 //  Created by Wesley Byrne on 2/14/18.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import CollectionView
 
-class FRCTests: XCTestCase, ResultsControllerDelegate {
+class FetchedRCTests: XCTestCase, ResultsControllerDelegate {
     
     fileprivate lazy var context : NSManagedObjectContext = {
         let model = TestModel()
@@ -72,14 +72,14 @@ class FRCTests: XCTestCase, ResultsControllerDelegate {
         _ = self.createItemsBySection(1, items: 10)
         let frc = FetchedResultsController<NSNumber, Child>(context: self.context, request: NSFetchRequest<Child>(entityName: "Child"))
         // Check ascending TRUE
-        frc.fetchRequest.sortDescriptors = [NSSortDescriptor(key: "displayOrder", ascending: true)]
+        frc.sortDescriptors = [SortDescriptor(\Child.displayOrder, ascending: true)]
         XCTAssertNoThrow(try frc.performFetch())
         for n in 0..<10 {
             XCTAssertEqual(frc.object(at: IndexPath.for(item: n, section: 0))!.displayOrder.intValue, n)
         }
         
         // Check ascending FALSE
-        frc.fetchRequest.sortDescriptors = [NSSortDescriptor(key: "displayOrder", ascending: false)]
+        frc.sortDescriptors = [SortDescriptor(\Child.displayOrder, ascending: false)]
         XCTAssertNoThrow(try frc.performFetch())
         for n in 0..<10 {
             XCTAssertEqual(frc.object(at: IndexPath.for(item: n, section: 0))!.displayOrder.intValue, 9 - n)

--- a/CollectionViewTests/MRCObjectTests.swift
+++ b/CollectionViewTests/MRCObjectTests.swift
@@ -336,11 +336,13 @@ class MRCObjectTests: XCTestCase, ResultsControllerDelegate {
         
         mrc.endEditing()
         self.waitForExpectations(timeout: 0.5) { (err) in
-            XCTAssertEqual(self.changeSet.items.inserted.count, 1)
-            XCTAssertEqual(self.changeSet.items.deleted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.inserted.count, 1)
+            XCTAssertEqual(self.changeSet.itemUpdates.deleted.count, 1)
             print("Done")
         }
     }
+    
+    
     
     var changeSet = CollectionViewResultsProxy()
     var _expectation : XCTestExpectation?

--- a/CollectionViewTests/ReaultionalRCTests.swift
+++ b/CollectionViewTests/ReaultionalRCTests.swift
@@ -1,0 +1,413 @@
+//
+//  RelationalRCTests.swift
+//  CollectionViewTests
+//
+//  Created by Wesley Byrne on 2/14/18.
+//  Copyright © 2018 Noun Project. All rights reserved.
+//
+
+import XCTest
+@testable import CollectionView
+
+
+
+class RelationalRCTests: XCTestCase, ResultsControllerDelegate {
+    
+    fileprivate lazy var context : NSManagedObjectContext = {
+        let model = TestModel()
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+        try! coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+        let ctx = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        ctx.persistentStoreCoordinator = coordinator
+        return ctx
+    }()
+    
+    fileprivate func createItemsBySection(_ count: Int, items perSection: Int) -> [[Child]] {
+        var res = [[Child]]()
+        for s in 0..<count {
+            var children = [Child]()
+            for _ in 0..<perSection {
+                let child = Child.createOrphan(in: self.context)
+                child.second = NSNumber(value: s)
+                child.displayOrder = NSNumber(value: children.count)
+                children.append(child)
+            }
+            res.append(children)
+        }
+        try! self.context.save()
+        return res
+    }
+    
+    override func tearDown() {
+        self.context.reset()
+        self._expectation = nil
+        self.changeSet.prepareForUpdates()
+        super.tearDown()
+    }
+    
+    private func createController(fetchSections: Bool = false) -> RelationalResultsController<Parent, Child> {
+        let rc = RelationalResultsController<Parent, Child>(context: self.context,
+                                                                 request: NSFetchRequest<Child>(entityName: "Child"),
+                                                                 sectionRequest: NSFetchRequest<Parent>(entityName: "Parent"),
+                                                                 sectionKeyPath: \Child.parent)
+        rc.delegate = self
+        rc.fetchSections = fetchSections
+        return rc
+    }
+
+    func test_performFetch_empty() {
+        let content = createController()
+        XCTAssertNoThrow(try content.performFetch())
+        XCTAssertEqual(content.numberOfSections, 0)
+    }
+    
+    func test_performFetch_fetchSectionsFalse() {
+        let content = createController()
+        _ = Parent.create(in: self.context, children: 0)
+        XCTAssertNoThrow(try content.performFetch())
+        XCTAssertEqual(content.numberOfSections, 0)
+    }
+    func test_performFetch_emptySection_fetchSections() {
+        let content = createController(fetchSections: true)
+        _ = Parent.create(in: self.context, children: 0)
+        XCTAssertNoThrow(try content.performFetch())
+        XCTAssertEqual(content.numberOfSections, 1)
+        XCTAssertEqual(content.numberOfObjects(in: 0), 0)
+    }
+    
+    
+    func test_sectionName_dispayConvertible() {
+        let content = createController(fetchSections: true)
+        let p = Parent.create(in: self.context, children: 0)
+        XCTAssertNoThrow(try content.performFetch())
+        XCTAssertEqual(content.sectionName(forSectionAt: IndexPath.zero), p.displayDescription)
+    }
+    
+    func test_sectionName_sectionNameKeyPath() {
+        let content = createController(fetchSections: true)
+        content.sectionNameKeyPath = \Parent.name
+        let p = Parent.create(in: self.context, children: 0)
+        XCTAssertNoThrow(try content.performFetch())
+        XCTAssertEqual(content.sectionName(forSectionAt: IndexPath.zero), p.name)
+    }
+    
+    
+    
+    func testSectionSortDescriptors() {
+        let content = createController(fetchSections: true)
+        for idx in 0..<10 {
+            let p = Parent.create(in: self.context)
+            p.displayOrder = NSNumber(value: idx)
+        }
+        
+        content.sectionSortDescriptors = [SortDescriptor(\Parent.displayOrder, ascending: true)]
+        XCTAssertNoThrow(try content.performFetch())
+        for n in 0..<10 {
+            let ip = IndexPath.for(item: 0, section: n)
+            let object = content.object(forSectionAt: ip)
+            XCTAssertEqual(object?.displayOrder.intValue, n)
+        }
+        
+        // Check ascending FALSE
+        content.sectionSortDescriptors = [SortDescriptor(\Parent.displayOrder, ascending: false)]
+        XCTAssertNoThrow(try content.performFetch())
+        for n in 0..<10 {
+            let ip = IndexPath.for(item: 0, section: n)
+            let object = content.object(forSectionAt: ip)
+            XCTAssertEqual(object?.displayOrder.intValue, 9 - n)
+        }
+    }
+    
+    
+    
+    // MARK: - Inserting
+    /*-------------------------------------------------------------------------------*/
+    
+    func test_insertFirstItem_noFetchSections() {
+        let content = createController(fetchSections: false)
+        try! content.performFetch()
+        self._expectation = expectation(description: "Delegate")
+        
+        _ = Parent.create(in: self.context, children: 1)
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 1)
+            XCTAssertEqual(content.numberOfObjects(in: 0), 1)
+        }
+    }
+    
+    func test_insertFirstSection_noFetchSections() {
+        let content = createController(fetchSections: false)
+        try! content.performFetch()
+        self._expectation = expectation(description: "Delegate")
+        
+        _ = Parent.create(in: self.context, children: 0)
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 0)
+        }
+    }
+    
+    func test_insertFirstSection_fetchSections() {
+        let content = createController(fetchSections: true)
+        try! content.performFetch()
+        self._expectation = expectation(description: "Delegate")
+        
+        _ = Parent.create(in: self.context, children: 1)
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 1)
+            XCTAssertEqual(content.numberOfObjects(in: 0), 1)
+        }
+    }
+    
+    func test_delegate_insertMultipleSections_noFetchSections() {
+        let content = createController(fetchSections: false)
+        try! content.performFetch()
+        self._expectation = expectation(description: "Delegate")
+        
+        _ = Parent.create(in: self.context, children: 1)
+        _ = Parent.create(in: self.context, children: 1)
+        _ = Parent.create(in: self.context, children: 1)
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 3)
+        }
+    }
+    
+    func test_delegate_insertMultipleEmptySections_fetchSections() {
+        let content = createController(fetchSections: true)
+        try! content.performFetch()
+        self._expectation = expectation(description: "Delegate")
+        
+        _ = Parent.create(in: self.context, children: 0)
+        _ = Parent.create(in: self.context, children: 0)
+        _ = Parent.create(in: self.context, children: 0)
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 3)
+        }
+    }
+    
+    
+    // MARK: - Removing Items
+    /*-------------------------------------------------------------------------------*/
+    
+    func test_delegate_removingItemsRemovesSections() {
+        // Fetch sections == true
+        let content = createController(fetchSections: false)
+        let parents = (0..<3).map { _ in
+            Parent.create(in: self.context, children: 1)
+        }
+        try! context.save()
+        try! content.performFetch()
+        XCTAssertEqual(content.numberOfSections, 3)
+        self._expectation = expectation(description: "Delegate")
+        for p in parents {
+            for c in p.children {
+                self.context.delete(c)
+            }
+        }
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 0)
+        }
+    }
+    
+    func test_delegate_removingItemsLeavesSections() {
+        // Fetch sections == true
+        let content = createController(fetchSections: true)
+        let parents = (0..<3).map { _ in
+            Parent.create(in: self.context, children: 1)
+        }
+        try! context.save()
+        try! content.performFetch()
+        XCTAssertEqual(content.numberOfSections, 3)
+        
+        self._expectation = expectation(description: "Delegate")
+        
+        for p in parents {
+            for c in p.children {
+                self.context.delete(c)
+            }
+        }
+        waitForExpectations(timeout: 0.1) { (err) in
+            XCTAssertEqual(content.numberOfSections, 3)
+            for idx in 0..<3 {
+                XCTAssertEqual(content.numberOfObjects(in: idx), 0)
+            }
+        }
+    }
+    
+    
+    // MARK: - Moving
+    /*-------------------------------------------------------------------------------*/
+    
+    func test_delegate_movingSections() {
+        let content = createController(fetchSections: false)
+        content.sectionSortDescriptors = [SortDescriptor(\Parent.displayOrder)]
+        
+        let parents : [Parent] = (0..<3).map {
+            let p = Parent.create(in: self.context, children: 1)
+            p.displayOrder = NSNumber(value: $0)
+            return p
+        }
+        try! context.save()
+        try! content.performFetch()
+        XCTAssertEqual(content.numberOfSections, 3)
+        self._expectation = expectation(description: "Delegate")
+        
+        // Reverse the display orders
+        for idx in 0..<3 {
+            parents[idx].displayOrder = NSNumber(value: 2 - idx)
+        }
+        waitForExpectations(timeout: 0.1) { (err) in
+            for idx in 0..<3 {
+                let ip = IndexPath.for(section: idx)
+                XCTAssertEqual(content.object(forSectionAt: ip), parents[2 - idx])
+            }
+        }
+    }
+    
+    var changeSet = CollectionViewResultsProxy()
+    var _expectation : XCTestExpectation?
+    func controllerWillChangeContent(controller: ResultsController) {
+        changeSet.prepareForUpdates()
+    }
+    func controller(_ controller: ResultsController, didChangeObject object: Any, at indexPath: IndexPath?, for changeType: ResultsControllerChangeType) {
+        changeSet.addChange(forItemAt: indexPath, with: changeType)
+    }
+    func controller(_ controller: ResultsController, didChangeSection section: Any, at indexPath: IndexPath?, for changeType: ResultsControllerChangeType) {
+        changeSet.addChange(forSectionAt: indexPath, with: changeType)
+    }
+    func controllerDidChangeContent(controller: ResultsController) {
+        _expectation?.fulfill()
+        _expectation = nil
+    }
+
+}
+
+
+// MARK: - Helpers
+/*-------------------------------------------------------------------------------*/
+
+
+fileprivate extension NSAttributeDescription {
+    convenience init(name: String, type: NSAttributeType) {
+        self.init()
+        self.name = name
+        self.attributeType = type
+    }
+}
+
+extension String {
+    static func random(_ length: Int) -> String {
+        let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        let len = UInt32(letters.length)
+        
+        var randomString = ""
+        for _ in 0 ..< length {
+            let rand = arc4random_uniform(len)
+            var nextChar = letters.character(at: Int(rand))
+            randomString += NSString(characters: &nextChar, length: 1) as String
+        }
+        return randomString
+    }
+}
+
+fileprivate class Parent : NSManagedObject, CustomDisplayStringConvertible {
+    @NSManaged var displayOrder : NSNumber
+    @NSManaged var name : String
+    @NSManaged var createdAt: Date
+    @NSManaged var children : Set<Child>
+    
+    static func create(in moc : NSManagedObjectContext, children: Int = 1) -> Parent {
+        let req = NSFetchRequest<Parent>(entityName: "Parent")
+        req.sortDescriptors = [NSSortDescriptor(key: "displayOrder", ascending: false)]
+        req.fetchLimit = 1
+        let _order = try! moc.fetch(req).first?.displayOrder.intValue ?? 0
+        let new = NSEntityDescription.insertNewObject(forEntityName: "Parent", into: moc) as! Parent
+        new.name = "Parent \(String.random(5))"
+        new.displayOrder = NSNumber(value: _order + 1)
+        new.createdAt = Date()
+        for _ in 0..<children {
+            _ = new.createChild()
+        }
+        return new
+    }
+    func createChild() -> Child {
+        let child = Child.createOrphan(in: self.managedObjectContext!)
+        let order = self.children.sorted(using: SortDescriptor(\Child.displayOrder)).last?.displayOrder.intValue ?? -1
+        child.displayOrder = NSNumber(value: order + 1)
+        child.parent = self
+        return child
+    }
+    var displayDescription: String {
+        return "Parent \(self.displayOrder)"
+    }
+}
+
+fileprivate class Child : NSManagedObject {
+    @NSManaged var second: NSNumber
+    @NSManaged var minute: NSNumber
+    @NSManaged var displayOrder : NSNumber
+    @NSManaged var createdAt: Date
+    @NSManaged var parent: Parent?
+    
+    static func createOrphan(in moc : NSManagedObjectContext) -> Child {
+        let child = NSEntityDescription.insertNewObject(forEntityName: "Child", into: moc) as! Child
+        child.displayOrder = NSNumber(value: 0)
+        let d = Date()
+        let s = Calendar.current.component(.second, from: d)
+        let m = Calendar.current.component(.minute, from: d)
+        child.createdAt = d
+        child.second = NSNumber(value: Int(s/6))
+        child.minute = NSNumber(value: Int(m/6))
+        return child
+    }
+}
+
+fileprivate class TestModel : NSManagedObjectModel {
+    override init() {
+        super.init()
+        
+        let parent = NSEntityDescription()
+        let child = NSEntityDescription()
+        
+        parent.name = "Parent"
+        parent.managedObjectClassName = Parent.className()
+        child.name = "Child"
+        child.managedObjectClassName = Child.className()
+        
+        let childrenRelationship = NSRelationshipDescription()
+        let parentRelationship = NSRelationshipDescription()
+        
+        childrenRelationship.name = "children"
+        childrenRelationship.destinationEntity = child
+        childrenRelationship.inverseRelationship = parentRelationship
+        childrenRelationship.maxCount = 0
+        childrenRelationship.minCount = 0
+        childrenRelationship.deleteRule = .cascadeDeleteRule
+        
+        parentRelationship.name = "parent"
+        parentRelationship.destinationEntity = parent
+        parentRelationship.inverseRelationship = childrenRelationship
+        parentRelationship.minCount = 0
+        parentRelationship.maxCount = 1
+        parentRelationship.isOptional = true
+        
+        parent.properties = [NSAttributeDescription(name: "displayOrder", type: .integer16AttributeType),
+                             NSAttributeDescription(name: "createdAt", type: .dateAttributeType),
+                             NSAttributeDescription(name: "name", type: .stringAttributeType),
+                             childrenRelationship]
+        child.properties = [NSAttributeDescription(name: "displayOrder", type: .integer16AttributeType),
+                            NSAttributeDescription(name: "createdAt", type: .dateAttributeType),
+                            NSAttributeDescription(name: "minute", type: .integer16AttributeType),
+                            NSAttributeDescription(name: "second", type: .integer16AttributeType),
+                            parentRelationship]
+        
+        self.entities = [parent, child]
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+
+


### PR DESCRIPTION
Collapsing sections is a fairly common use case but managing that state can get a little complicated. 

With CollectionViewProvider already able to handle connecting your data to your collection view and managing options like empty placeholders, adding collapsable state management is a welcome addition.