### PR TITLE
Reloading Items & Sections, open proxy, and context observer

### DIFF
--- a/CollectionView.xcodeproj/project.pbxproj
+++ b/CollectionView.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1CA2942720D45657008112D5 /* CVListLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA2942620D45657008112D5 /* CVListLayoutTests.swift */; };
 		1CB3A3D02075651900A2AB9B /* ReaultionalRCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB3A3CF2075651900A2AB9B /* ReaultionalRCTests.swift */; };
 		1CC05C221FF6F564001E6936 /* MutableResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC05C211FF6F564001E6936 /* MutableResultsController.swift */; };
+		DE0A5253211BAC7C00FD8365 /* ContextObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0A5252211BAC7C00FD8365 /* ContextObserver.swift */; };
 		DE13C18B1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */; };
 		DE297DE01E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE297DDF1E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift */; };
 		DE316FAD1CC72ABC00F763E6 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9072171CAC807900AD0E37 /* ClipView.swift */; };
@@ -76,6 +77,7 @@
 		1CA2942620D45657008112D5 /* CVListLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVListLayoutTests.swift; sourceTree = "<group>"; };
 		1CB3A3CF2075651900A2AB9B /* ReaultionalRCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaultionalRCTests.swift; sourceTree = "<group>"; };
 		1CC05C211FF6F564001E6936 /* MutableResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableResultsController.swift; sourceTree = "<group>"; };
+		DE0A5252211BAC7C00FD8365 /* ContextObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextObserver.swift; sourceTree = "<group>"; };
 		DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectContextObservationCoordinator.swift; sourceTree = "<group>"; };
 		DE1EE9A42072B00B00B76FE2 /* CollapsableCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsableCollectionViewProvider.swift; sourceTree = "<group>"; };
 		DE297DDF1E6A8B5400AAFC2A /* SupplementaryViewIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupplementaryViewIdentifier.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				DE13C18A1E4CE46100CEC80C /* ManagedObjectContextObservationCoordinator.swift */,
 				DEE5F7AD1E92D79A0002079C /* MergedFetchedResultsController.swift */,
 				DE98600A1E6F956100B6A3EC /* FetchedSetController.swift */,
+				DE0A5252211BAC7C00FD8365 /* ContextObserver.swift */,
 			);
 			name = ResultsController;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				1CC05C221FF6F564001E6936 /* MutableResultsController.swift in Sources */,
 				DE3E47561E4259B800F19D9E /* EditDistance.swift in Sources */,
 				DEB7366C1E8599E7008467F8 /* CollectionViewPreviewCell.swift in Sources */,
+				DE0A5253211BAC7C00FD8365 /* ContextObserver.swift in Sources */,
 				DEF14B991CBDD83B00553CEF /* CollectionViewColumnLayout.swift in Sources */,
 				1C2DC5171E329CA000EBC234 /* IndexedSet.swift in Sources */,
 				DE82E9591D78B78300346B9E /* CollectionViewLayoutAttributes.swift in Sources */,

--- a/CollectionView/CollectionView.swift
+++ b/CollectionView/CollectionView.swift
@@ -1266,7 +1266,17 @@ open class CollectionView : ScrollView, NSDraggingSource {
         _editing = 0
         
         guard !self._updateContext.items.isEmpty || !self._updateContext.sections.isEmpty else {
-            completion?(true)
+            
+            if _updateContext.reloadedItems.count > 0 {
+                for ip in _updateContext.reloadedItems {
+                    guard let cell = self.contentDocumentView.preparedCellIndex[ip] else { continue }
+                    self.contentDocumentView.preparedCellIndex[ip] = _prepareReplacementCell(for: cell, at: ip)
+                }
+                self.reloadLayout(animated, scrollPosition: .none, completion: completion)
+            }
+            else {
+                completion?(true)
+            }
             return
         }
         

--- a/CollectionView/CollectionView.swift
+++ b/CollectionView/CollectionView.swift
@@ -9,20 +9,6 @@
 import Foundation
 import AppKit
 
-extension IndexSet {
-    var indices : [Element] {
-        var res = [Element]()
-        for idx in self {
-            res.append(idx)
-        }
-        return res
-    }
-    var normalized : IndexSet {
-        return self.filteredIndexSet(includeInteger: { (idx) -> Bool in
-            return idx >= 0
-        })
-    }
-}
 
 /**
  A Collection View manages the presentation of items, your app's main job is to provide the data that those items are to represent.

--- a/CollectionView/CollectionView.swift
+++ b/CollectionView/CollectionView.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
+import AppKit
 
 extension IndexSet {
-    
     var indices : [Element] {
         var res = [Element]()
         for idx in self {
@@ -17,13 +17,11 @@ extension IndexSet {
         }
         return res
     }
-    
     var normalized : IndexSet {
         return self.filteredIndexSet(includeInteger: { (idx) -> Bool in
             return idx >= 0
         })
     }
-    
 }
 
 /**
@@ -973,15 +971,19 @@ open class CollectionView : ScrollView, NSDraggingSource {
             for viewRef in item.value {
                 let id = viewRef.id
                 let oldView = viewRef.view
-                
                 contentDocumentView.preparedSupplementaryViewIndex.removeValue(forKey: id)
                 updates.append(ItemUpdate(view: oldView, attrs: oldView.attributes!, type: .remove, identifier: id))
             }
-            
         }
         self.contentDocumentView.pendingUpdates.append(contentsOf: updates)
     }
     
+    public func reloadSections(_ sections: IndexSet, animated: Bool) {
+        guard !sections.isEmpty else { return }
+        self.beginEditing()
+        self._updateContext.reloadSections.formUnion(sections)
+        self.endEditing(animated)
+    }
     
 	/**
 	Insert sections at the given indexes
@@ -992,7 +994,7 @@ open class CollectionView : ScrollView, NSDraggingSource {
      - Note: If called within performBatchUpdate(_:completion:) sections should be the final indexes after other updates are applied
 	*/
     public func insertSections(_ sections: IndexSet, animated: Bool) {
-        guard sections.count > 0 else { return }
+        guard !sections.isEmpty else { return }
         self.beginEditing()
         self._updateContext.sections.inserted.formUnion(sections)
         self.endEditing(animated)
@@ -1130,7 +1132,6 @@ open class CollectionView : ScrollView, NSDraggingSource {
         var deleted   = IndexSet() // Original Indexes for deleted sections
         var inserted  = IndexSet() // Destination Indexes for inserted sections
         var moved = IndexedSet<Int, Int>() // Source and Destination indexes for moved sections
-        
         var isEmpty : Bool {
             return deleted.isEmpty && inserted.isEmpty && moved.isEmpty
         }
@@ -1232,6 +1233,7 @@ open class CollectionView : ScrollView, NSDraggingSource {
         var sections = SectionTracker()
         var items = ItemTracker()
         var reloadedItems = Set<IndexPath>() // Track reloaded items to reload after adjusting IPs
+        var reloadSections = IndexSet()
         
         var updates = [ItemUpdate]()
         
@@ -1241,8 +1243,11 @@ open class CollectionView : ScrollView, NSDraggingSource {
             updates.removeAll()
             reloadedItems.removeAll()
         }
+        
+        var isEmpty : Bool {
+            return sections.isEmpty && items.isEmpty && reloadedItems.isEmpty && reloadSections.isEmpty
+        }
     }
-    
     
     private var _updateContext = UpdateContext()
     private var _editing = 0
@@ -1265,8 +1270,34 @@ open class CollectionView : ScrollView, NSDraggingSource {
         }
         _editing = 0
         
+        guard !self._updateContext.isEmpty else {
+            completion?(true)
+            return
+        }
+        
+        let oldData = self.sections
+        self._reloadDataCounts()
+        let newData = self.sections
+        
+        for idx in self._updateContext.reloadSections {
+            // Reuse existing operation to reload, delete, and insert items in the section as needed
+            precondition(!self._updateContext.sections.deleted.contains(idx), "Cannot delete section that is also being reloaded")
+            let oldCount = oldData[idx]
+            let newCount = newData[idx]
+            let shared = min(oldCount, newCount)
+            let update = Set(IndexPath.inRange(0..<shared, section: idx))
+            self._updateContext.reloadedItems.formUnion(update)
+            if oldCount > newCount {
+                let delete = Set(IndexPath.inRange(shared..<oldCount, section: idx))
+                self._updateContext.items.deleted.formUnion(delete)
+            }
+            else if oldCount < newCount {
+                let insert = IndexPath.inRange(shared..<newCount, section: idx)
+                self._updateContext.items.inserted.formUnion(insert)
+            }
+        }
+        
         guard !self._updateContext.items.isEmpty || !self._updateContext.sections.isEmpty else {
-            
             if _updateContext.reloadedItems.count > 0 {
                 for ip in _updateContext.reloadedItems {
                     guard let cell = self.contentDocumentView.preparedCellIndex[ip] else { continue }
@@ -1279,11 +1310,6 @@ open class CollectionView : ScrollView, NSDraggingSource {
             }
             return
         }
-        
-        let oldData = self.sections
-        self._reloadDataCounts()
-        let newData = self.sections
-        
         
         // Validate the section changes
         var sectionDelta = self._updateContext.sections.inserted.count - self._updateContext.sections.deleted.count

--- a/CollectionView/CollectionViewProvider.swift
+++ b/CollectionView/CollectionViewProvider.swift
@@ -122,7 +122,7 @@ public extension CollectionViewResultsProxy {
     ///   - edits: A set of EditDistance Edits
     ///   - section: The section the changes should apply to
     /// - Returns: A new proxy with the edits added
-    public func addEdits<T:Hashable>(from edits: EditDistance<T>, for section: Int = 0) {
+    public func addEdits<T:Collection>(from edits: EditDistance<T>, for section: Int = 0) where T.Iterator.Element: Hashable, T.Index == Int {
         for e in edits.edits {
             switch e.operation {
             case .deletion:

--- a/CollectionView/ContextObserver.swift
+++ b/CollectionView/ContextObserver.swift
@@ -1,0 +1,63 @@
+//
+//  EntityObserver.swift
+//  CollectionView
+//
+//  Created by Wesley Byrne on 8/8/18.
+//  Copyright © 2018 Noun Project. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+open class ContextObserver {
+    
+    public var wait: Bool = true
+    public var managedObjectContext : NSManagedObjectContext {
+        didSet{
+            if oldValue != managedObjectContext {
+                self.unregister()
+            }
+        }
+    }
+    public init(context: NSManagedObjectContext) {
+        self.managedObjectContext = context
+    }
+    open func shouldRegister() -> Bool {
+        return true
+    }
+    
+    private var _registered : Bool = false
+    public func register() {
+        guard !_registered, shouldRegister() else { return }
+        self._registered = true
+        ManagedObjectContextObservationCoordinator.shared.add(context: self.managedObjectContext)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleChangeNotification(_:)), name: ManagedObjectContextObservationCoordinator.Notification.name, object: self.managedObjectContext)    }
+    
+    public func unregister() {
+        guard _registered else { return }
+        self._registered = false
+        ManagedObjectContextObservationCoordinator.shared.remove(context: self.managedObjectContext)
+        NotificationCenter.default.removeObserver(self, name: ManagedObjectContextObservationCoordinator.Notification.name, object: self.managedObjectContext)
+    }
+    
+    open func process( _ changes: [NSEntityDescription: (inserted: Set<NSManagedObject>, deleted: Set<NSManagedObject>, updated: Set<NSManagedObject>)]) {
+        
+    }
+    @objc func handleChangeNotification(_ notification: Notification) {
+        guard let changes = notification.userInfo?[ManagedObjectContextObservationCoordinator.Notification.changeSetKey] as? [NSEntityDescription:ManagedObjectContextObservationCoordinator.EntityChangeSet] else {
+            return
+        }
+        func run() {
+            self.process(changes.mapValues {
+                return (inserted: $0.inserted, deleted: $0.deleted, updated: $0.updated)
+                }
+            )
+        }
+        if wait {
+            self.managedObjectContext.performAndWait { run() }
+        }
+        else {
+            self.managedObjectContext.perform { run() }
+        }
+    }
+}

--- a/CollectionView/DataStructures/EditDistance/EditDistance.swift
+++ b/CollectionView/DataStructures/EditDistance/EditDistance.swift
@@ -31,6 +31,11 @@ public enum EditOperation {
     }
 }
 
+
+
+
+
+
 public struct Edit<T: Hashable> : CustomStringConvertible, Hashable {
     
     public let operation: EditOperation

--- a/CollectionView/ManagedObjectContextObservationCoordinator.swift
+++ b/CollectionView/ManagedObjectContextObservationCoordinator.swift
@@ -99,6 +99,10 @@ class ManagedObjectContextObservationCoordinator {
             self.entity = obj.entity
             self.updated(obj)
         }
+
+        var isEmpty : Bool {
+            return inserted.isEmpty && deleted.isEmpty && updated.isEmpty
+        }
         
         @discardableResult mutating func inserted(_ object: NSManagedObject) -> Bool {
             return inserted.insert(object).inserted


### PR DESCRIPTION
### Reloading 

`reloadItems(_:)`  would be ignored if no other changes were made in the same editing session. That has been fixed and items will now reload.

Adds `reloadSections(_:)` to drop and replace all items in a section. 


### CollectionViewProxy

The proxy object is useful to translating changes in a data set (in particular a results controller) to collection view edits. The class is now more public/open to make it possible to create custom handling when transferring these edits to a collection view.

### Context Observer

While FetchedResultsController is great at managing changes to objects, some data sets may be a combination of properties from multiple objects. FetchedSetController is an example of this and is useful when the order and organization of objects is unimportant. ContextObserver now provides a base for this type of functionality, ready to expend as needed. 

An example is a TagController for managing shared tags from a set of objects. The ContextObserver subclass can watch for changes from a set of objects with a `tags` and handle the changes as needed without the unnecessary organizational overhead of a ResultsController.